### PR TITLE
Ensure circle drawing completes full rotation

### DIFF
--- a/pyautogui_draw_circle.py
+++ b/pyautogui_draw_circle.py
@@ -3,21 +3,20 @@
 #
 #draw a circle by mouse
 
-import pyautogui
 import math
- 
+import pyautogui
+
 width, height = pyautogui.size()
- 
+
 r = 250  # radius
 # Center point
-o_x = width/2
-o_y = height/2
- 
-pi = 3.1415926
- 
-for i in range(10):   # 10times
-	for angle in range(0, 360, 5):  # 360 degree
-		X = o_x + r * math.sin(angle*pi/180)
-		Y = o_y + r * math.cos(angle*pi/180)
- 
-		pyautogui.moveTo(X, Y, duration=0.1)
+o_x = width / 2
+o_y = height / 2
+
+for _ in range(10):  # draw circle 10 times
+    for angle in range(0, 361, 5):  # 360 degrees inclusive
+        radians = math.radians(angle)
+        X = o_x + r * math.sin(radians)
+        Y = o_y + r * math.cos(radians)
+
+        pyautogui.moveTo(X, Y, duration=0.1)

--- a/test_circle_points.py
+++ b/test_circle_points.py
@@ -1,0 +1,15 @@
+import math
+
+def generate_points(r=250, center=(0, 0)):
+    o_x, o_y = center
+    points = []
+    for angle in range(0, 361, 5):
+        rad = math.radians(angle)
+        x = o_x + r * math.sin(rad)
+        y = o_y + r * math.cos(rad)
+        points.append((round(x, 5), round(y, 5)))
+    return points
+
+def test_circle_closed():
+    pts = generate_points()
+    assert pts[0] == pts[-1]


### PR DESCRIPTION
## Summary
- Fix circle drawing script to use radians and cover full 360° for closed shape
- Add unit test confirming circle start and end points match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3ff756ec832899302d205d6ec136